### PR TITLE
Upd. plot_threshold_metrics w/ new lookup_kwgs and legend logic

### DIFF
--- a/src/model_metrics/model_evaluator.py
+++ b/src/model_metrics/model_evaluator.py
@@ -2544,6 +2544,7 @@ def plot_threshold_metrics(
     baseline_thresh=True,
     curve_kwgs=None,
     baseline_kwgs=None,
+    lookup_kwgs=None,
     save_plot=False,
     image_path_png=None,
     image_path_svg=None,
@@ -2571,6 +2572,9 @@ def plot_threshold_metrics(
       (default: None).
     - baseline_kwgs: Dictionary of keyword arguments for baseline styling
       (default: None).
+    - lookup_kwgs: Dictionary of keyword arguments for styling the lookup
+      threshold line (e.g., {"linestyle": "--", "color": "orange",
+      "linewidth": 2}). Default is gray dashed line.
     - save_plot: Boolean flag to save the plot (default: False).
     - image_path_png: Path to save the plot as a PNG image (default: None).
     - image_path_svg: Path to save the plot as an SVG image (default: None).
@@ -2586,6 +2590,13 @@ def plot_threshold_metrics(
         "linestyle": ":",
         "linewidth": 1.5,
         "color": "black",
+        "alpha": 0.7,
+    }
+
+    lookup_kwgs = lookup_kwgs or {
+        "linestyle": "--",
+        "linewidth": 1.5,
+        "color": "gray",
         "alpha": 0.7,
     }
 
@@ -2614,6 +2625,12 @@ def plot_threshold_metrics(
 
     # Find the best threshold for a given metric (if requested)
     best_threshold = None
+    if (lookup_metric is not None and lookup_value is None) or (
+        lookup_value is not None and lookup_metric is None
+    ):
+        raise ValueError(
+            "Both `lookup_metric` and `lookup_value` must be provided together."
+        )
     if lookup_metric and lookup_value is not None:
         metric_dict = {
             "precision": (precision[:-1], thresholds),
@@ -2642,7 +2659,7 @@ def plot_threshold_metrics(
             )
 
     # Create the plot
-    fig, ax = plt.subplots(figsize=figsize)
+    _, ax = plt.subplots(figsize=figsize)
 
     # Plot Precision, Recall, F1 Score vs. Thresholds
     ax.plot(
@@ -2684,9 +2701,8 @@ def plot_threshold_metrics(
     if best_threshold is not None:
         ax.axvline(
             x=best_threshold,
-            linestyle="--",
-            color="gray",
             label=f"Best Threshold: {round(best_threshold, decimal_places)}",
+            **lookup_kwgs,
         )
 
     # Apply labels, legend, and formatting
@@ -2706,21 +2722,28 @@ def plot_threshold_metrics(
             fontsize=label_fontsize,
         )
 
-    # Move the legend below the plot
     ax.legend(
         loc="upper center",
-        bbox_to_anchor=(0.5, -0.15 * (figsize[0] / 10)),  # Scales with width
-        ncol=int(figsize[0] // 2),  # Adjust columns dynamically
-        fontsize=label_fontsize,
-        columnspacing=1.5,
-        handletextpad=1.2,
+        bbox_to_anchor=(0.5, -0.15),  # Push further down to ensure it's outside
+        ncol=3,
+        fontsize=tick_fontsize,
+        frameon=False,
     )
-    # Save plot if required
-    if save_plot:
-        if image_path_png:
-            fig.savefig(image_path_png, format="png", bbox_inches="tight")
-        if image_path_svg:
-            fig.savefig(image_path_svg, format="svg", bbox_inches="tight")
+
+    if lookup_metric:
+        save_plot_images(
+            filename=f"threshold_metrics_{lookup_metric}",
+            save_plot=save_plot,
+            image_path_png=image_path_png,
+            image_path_svg=image_path_svg,
+        )
+    else:
+        save_plot_images(
+            filename="threshold_metrics",
+            save_plot=save_plot,
+            image_path_png=image_path_png,
+            image_path_svg=image_path_svg,
+        )
 
     # Display the plot
     plt.show()

--- a/unittests/test_model_evaluator.py
+++ b/unittests/test_model_evaluator.py
@@ -24,7 +24,6 @@ from model_metrics.model_evaluator import (
     extract_model_name,
     show_lift_chart,
     show_gain_chart,
-    show_ks_curve,
     plot_threshold_metrics,
 )
 
@@ -1970,122 +1969,6 @@ def test_show_calibration_curve_invalid_combination_with_group_category(
             group_category=group,
             grid=True,
         )
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_single_model(
-    mock_show,
-    trained_model,
-    sample_data,
-):
-    """Test show_ks_curve with a single model."""
-    X, y = sample_data  # Get sample test data
-    try:
-        show_ks_curve(trained_model, X, y, save_plot=False)
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed with a single model: {e}")
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_multiple_models(
-    mock_show,
-    trained_model,
-    sample_data,
-):
-    """Test show_ks_curve with multiple models."""
-    X, y = sample_data  # Get sample test data
-    # Using the same model 2x for simplicity
-    model = [trained_model, trained_model]
-    try:
-        show_ks_curve(model, X, y, save_plot=False)
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed with multiple models: {e}")
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_saves_plot(
-    mock_show,
-    trained_model,
-    sample_data,
-    tmp_path,
-):
-    """Test if show_ks_curve saves the plot correctly."""
-    X, y = sample_data  # Get sample test data
-    image_path_png = tmp_path / "ks_curve.png"
-    image_path_svg = tmp_path / "ks_curve.svg"
-
-    try:
-        show_ks_curve(
-            trained_model,
-            X,
-            y,
-            save_plot=True,
-            image_path_png=str(image_path_png),
-            image_path_svg=str(image_path_svg),
-        )
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed when saving plot: {e}")
-
-    assert image_path_png.exists(), "PNG image was not saved."
-    assert image_path_svg.exists(), "SVG image was not saved."
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_empty_groups(
-    mock_show,
-    trained_model,
-    sample_data,
-):
-    """Test show_ks_curve when one group is empty."""
-    X, _ = sample_data  # Extract feature data
-    y = np.zeros(len(X))  # Set all labels to zero (no positives)
-
-    try:
-        show_ks_curve(trained_model, X, y, save_plot=False)
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed when handling empty groups: {e}")
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_custom_threshold(
-    mock_show,
-    trained_model,
-    sample_data,
-):
-    """Test show_ks_curve with a custom threshold."""
-    X, y = sample_data  # Get sample test data
-    try:
-        show_ks_curve(
-            trained_model,
-            X,
-            y,
-            model_threshold=0.7,
-            save_plot=False,
-        )
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed with custom threshold: {e}")
-
-
-@patch("matplotlib.pyplot.show")
-def test_show_ks_curve_custom_labels(
-    mock_show,
-    trained_model,
-    sample_data,
-):
-    """Test show_ks_curve with custom axis labels and title."""
-    X, y = sample_data  # Get sample test data
-    try:
-        show_ks_curve(
-            trained_model,
-            X,
-            y,
-            xlabel="Custom X",
-            ylabel="Custom Y",
-            title="Custom Title",
-            save_plot=False,
-        )
-    except Exception as e:
-        pytest.fail(f"show_ks_curve failed with custom labels: {e}")
 
 
 def test_custom_help(capsys):


### PR DESCRIPTION
- Introduced the `lookup_kwgs` parameter to the `plot_threshold_metrics function`, enabling custom styling of the "best threshold" vertical line identified via `lookup_metric `and `lookup_value`.
-  Default style: dashed gray line (`"--", linewidth=1.5, color="gray", alpha=0.7`).
- Updated logic to apply `lookup_kwgs` when drawing the lookup threshold line (`ax.axvline(...)`).
- Ensures symmetry with `baseline_kwgs` and `curve_kwgs` for a more customizable plotting interface.
- Updated legend position for consistency 
- Removed anything related to `show_ks_curve`, especially as it pertains to pytests